### PR TITLE
Specify erlang for syntax highlighting

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -102,7 +102,7 @@ modules_enabled = {
 
 #### v2.13 and older
 
-```txt
+```erlang
 {acl, admin, {user, "root", "example.org"}}.
 {acl, admin, {user, "admin", "component.example.org"}}.
 ```


### PR DESCRIPTION
Use erlang in place of txt for proper syntax highlighting in the README.
