### PR TITLE
Removed the value element if already exist

### DIFF
--- a/src/ServiceAdmin.coffee
+++ b/src/ServiceAdmin.coffee
@@ -71,6 +71,7 @@ class ServiceAdmin
     x.attrs.type = "submit"
     for xF in x.getChildren "field"
       if (val = fields[xF.attrs.var])?
+        xF.remove("value") if xF.getChild("value") != null
         if val instanceof Array
           xF.c("value").t(v).up() for v in val
         else


### PR DESCRIPTION
The package doesn't work with Tigase xmpp server:
Tigase sends an empty <value/> element in registration form and this package only appends a new value which cause Tigase to fail.
Fixed by removing the value element if already exists.
